### PR TITLE
Update tile URLs from 2026-02-27 update

### DIFF
--- a/src/core/overlay.ts
+++ b/src/core/overlay.ts
@@ -74,7 +74,7 @@ export function extractPixelCoords(pixelUrl: string) {
 export function matchTileUrl(urlStr: string) {
   try {
     const u = new URL(urlStr, location.href);
-    if (u.hostname !== 'backend.wplace.live' || !u.pathname.startsWith('/tile/')) return null;
+    if (u.hostname !== 'backend.wplace.live' || !(u.pathname.startsWith('/files/') || u.pathname.startsWith('/tile/'))) return null;
     const m = u.pathname.match(/\/(\d+)\/(\d+)\.png$/i);
     if (!m) return null;
     return { chunk1: parseInt(m[1], 10), chunk2: parseInt(m[2], 10) };

--- a/src/core/overlay.ts
+++ b/src/core/overlay.ts
@@ -74,7 +74,7 @@ export function extractPixelCoords(pixelUrl: string) {
 export function matchTileUrl(urlStr: string) {
   try {
     const u = new URL(urlStr, location.href);
-    if (u.hostname !== 'backend.wplace.live' || !u.pathname.startsWith('/files/')) return null;
+    if (u.hostname !== 'backend.wplace.live' || !u.pathname.startsWith('/tile/')) return null;
     const m = u.pathname.match(/\/(\d+)\/(\d+)\.png$/i);
     if (!m) return null;
     return { chunk1: parseInt(m[1], 10), chunk2: parseInt(m[2], 10) };


### PR DESCRIPTION
This fixes the overlay not rendering since the aforementioned update.